### PR TITLE
fix: normalize SpircWrapper package casing to core.spirc

### DIFF
--- a/app/src/main/java/cc/tomko/outify/OutifyApplication.kt
+++ b/app/src/main/java/cc/tomko/outify/OutifyApplication.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.glance.GlanceId
 import androidx.media3.common.util.UnstableApi
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.spirc.SpircController
 import cc.tomko.outify.data.database.AppDatabase
 import cc.tomko.outify.ui.viewmodel.detail.DetailViewModelStore

--- a/app/src/main/java/cc/tomko/outify/core/spirc/SpircController.kt
+++ b/app/src/main/java/cc/tomko/outify/core/spirc/SpircController.kt
@@ -3,7 +3,6 @@ package cc.tomko.outify.core.spirc
 import android.util.Log
 import cc.tomko.outify.core.Session
 import cc.tomko.outify.core.SessionCallback
-import cc.tomko.outify.core.Spirc.SpircWrapper
 import cc.tomko.outify.core.model.OutifyUri
 import cc.tomko.outify.data.repository.SettingsRepository
 import cc.tomko.outify.playback.PlaybackStateHolder

--- a/app/src/main/java/cc/tomko/outify/core/spirc/SpircWrapper.kt
+++ b/app/src/main/java/cc/tomko/outify/core/spirc/SpircWrapper.kt
@@ -1,4 +1,4 @@
-package cc.tomko.outify.core.Spirc
+package cc.tomko.outify.core.spirc
 
 import android.content.Context
 import android.content.Intent

--- a/app/src/main/java/cc/tomko/outify/core/spirc/VolumeController.kt
+++ b/app/src/main/java/cc/tomko/outify/core/spirc/VolumeController.kt
@@ -2,7 +2,6 @@ package cc.tomko.outify.core.spirc
 
 import android.content.Context
 import android.media.AudioManager
-import cc.tomko.outify.core.Spirc.SpircWrapper
 import cc.tomko.outify.playback.PlaybackStateHolder
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/cc/tomko/outify/playback/Player.kt
+++ b/app/src/main/java/cc/tomko/outify/playback/Player.kt
@@ -13,7 +13,7 @@ import androidx.media3.common.audio.AudioFocusManager
 import androidx.media3.common.util.Log
 import androidx.media3.common.util.UnstableApi
 import cc.tomko.outify.ALBUM_COVER_URL
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.CoverSize
 import cc.tomko.outify.core.model.Episode
 import cc.tomko.outify.core.model.Track

--- a/app/src/main/java/cc/tomko/outify/services/LikedTileService.kt
+++ b/app/src/main/java/cc/tomko/outify/services/LikedTileService.kt
@@ -5,7 +5,7 @@ import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import android.util.Log
 import cc.tomko.outify.core.AuthManager
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.OutifyUri
 import cc.tomko.outify.data.repository.LikedRepository
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/cc/tomko/outify/services/PlaybackService.kt
+++ b/app/src/main/java/cc/tomko/outify/services/PlaybackService.kt
@@ -33,7 +33,7 @@ import cc.tomko.outify.MainActivity
 import cc.tomko.outify.MediaSessionConstants
 import cc.tomko.outify.R
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.SpotifyUri
 import cc.tomko.outify.data.dao.LikedDao
 import cc.tomko.outify.data.metadata.TrackMetadataHelper

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/HomeViewModel.kt
@@ -6,7 +6,7 @@ import cc.tomko.outify.core.AuthManager
 import cc.tomko.outify.core.AuthStateEvent
 import cc.tomko.outify.core.AuthStateEventBus
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.UserProfile
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Profile

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/MainViewModel.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.EpisodeDetails
 import cc.tomko.outify.core.RadioResult
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.OutifyUri
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Track

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/SearchViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.R
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.UserProfile
 import cc.tomko.outify.core.model.*
 import cc.tomko.outify.data.dao.LikedDao

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/bottomsheet/LyricsViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/bottomsheet/LyricsViewModel.kt
@@ -2,7 +2,7 @@ package cc.tomko.outify.ui.viewmodel.bottomsheet
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.LyricLine
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Track

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/bottomsheet/PlaybackDevicesViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/bottomsheet/PlaybackDevicesViewModel.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.Device
 import cc.tomko.outify.core.model.DevicesResponse
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/detail/AlbumDetailViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/detail/AlbumDetailViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Track
 import cc.tomko.outify.core.model.toPlayableAudio

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/detail/ArtistDetailViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/detail/ArtistDetailViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.Album
 import cc.tomko.outify.core.model.Artist
 import cc.tomko.outify.core.model.PlayableAudio

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/detail/PlaylistDetailViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/detail/PlaylistDetailViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.UserProfile
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Playlist

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/detail/TrackDetailViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/detail/TrackDetailViewModel.kt
@@ -3,7 +3,7 @@ package cc.tomko.outify.ui.viewmodel.detail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Track
 import cc.tomko.outify.core.model.toPlayableAudio

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/ArtistViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/ArtistViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.Album
 import cc.tomko.outify.core.model.Artist
 import cc.tomko.outify.core.model.PlayableAudio

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/LibraryViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/LibraryViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.SpClient
 import cc.tomko.outify.core.EpisodeDetails
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.UserProfile
 import cc.tomko.outify.core.model.Album
 import cc.tomko.outify.core.model.Episode

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/LikedViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/LikedViewModel.kt
@@ -3,7 +3,7 @@ package cc.tomko.outify.ui.viewmodel.library
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.CoverSize
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Track

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/PlaylistViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/PlaylistViewModel.kt
@@ -2,7 +2,7 @@ package cc.tomko.outify.ui.viewmodel.library
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.UserProfile
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Playlist

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/ProfileDetailViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/ProfileDetailViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.UserProfile
 import cc.tomko.outify.core.model.Profile
 import cc.tomko.outify.data.dao.LikedDao

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/ShowDetailViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/ShowDetailViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.EpisodeDetails
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.ConsumptionOrder
 import cc.tomko.outify.core.model.Episode
 import cc.tomko.outify.core.model.PlayableAudio

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/album/AlbumViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/library/album/AlbumViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Track
 import cc.tomko.outify.data.dao.LikedDao

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/player/MiniPlayerViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/player/MiniPlayerViewModel.kt
@@ -2,7 +2,7 @@ package cc.tomko.outify.ui.viewmodel.player
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Track
 import cc.tomko.outify.playback.PlaybackStateHolder

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/player/MultiQueueViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/player/MultiQueueViewModel.kt
@@ -2,7 +2,7 @@ package cc.tomko.outify.ui.viewmodel.player
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Track
 import cc.tomko.outify.data.queue.SavedQueue

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/player/PlayerViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/player/PlayerViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.CoverSize
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.LyricLine

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/player/QueueViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/player/QueueViewModel.kt
@@ -2,7 +2,7 @@ package cc.tomko.outify.ui.viewmodel.player
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.PlayableAudio
 import cc.tomko.outify.core.model.Track
 import cc.tomko.outify.core.model.toPlayableAudio

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/settings/DebugViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/settings/DebugViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.tomko.outify.core.AuthManager
 import cc.tomko.outify.core.SpClient
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.CurrentUserProfile
 import cc.tomko.outify.data.repository.SettingsRepository
 import cc.tomko.outify.playback.PlaybackStateHolder

--- a/app/src/main/java/cc/tomko/outify/ui/viewmodel/settings/SettingsViewModel.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/viewmodel/settings/SettingsViewModel.kt
@@ -2,7 +2,7 @@ package cc.tomko.outify.ui.viewmodel.settings
 
 import androidx.lifecycle.ViewModel
 import cc.tomko.outify.core.Session
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 

--- a/app/src/main/java/cc/tomko/outify/ui/widgets/PlaybackWidget.kt
+++ b/app/src/main/java/cc/tomko/outify/ui/widgets/PlaybackWidget.kt
@@ -50,7 +50,7 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import cc.tomko.outify.ALBUM_COVER_URL
 import cc.tomko.outify.MainActivity
-import cc.tomko.outify.core.Spirc.SpircWrapper
+import cc.tomko.outify.core.spirc.SpircWrapper
 import cc.tomko.outify.core.model.CoverSize
 import cc.tomko.outify.core.model.OutifyUri
 import cc.tomko.outify.core.model.PlayableAudio


### PR DESCRIPTION
## Summary
- `SpircWrapper.kt` declares `package cc.tomko.outify.core.Spirc` (capital `S`) while every other file in `core/spirc/` uses `cc.tomko.outify.core.spirc`.
- Kotlin accepts the mismatch, so the build passes on case-sensitive filesystems (Linux CI). On Windows and macOS the two package output directories collide and `javac` fails on the KSP/Hilt generated factories with ~100 `cannot find symbol: class SpircWrapper` errors.

## Changes
- Lowercase the package declaration in `SpircWrapper.kt`.
- Update the 27 files importing `core.Spirc.SpircWrapper` to `core.spirc.SpircWrapper`.
- Drop the now-redundant same-package imports in `SpircController.kt` and `VolumeController.kt`.

No behavior change; the class only moves to the package its directory already implies.

## Testing
- [x] `./gradlew assembleRelease` on Windows 11 (JDK 21, Gradle 9.5): fails before this change, succeeds after.
- [x] Resulting APK installed and running on an arm64 device with a locally built `librespot_ffi`.