### PR TITLE
Fix player controls on compact portrait layouts

### DIFF
--- a/app/src/main/java/cc/tomko/outify/MainActivity.kt
+++ b/app/src/main/java/cc/tomko/outify/MainActivity.kt
@@ -467,6 +467,18 @@ class MainActivity : ComponentActivity() {
                                             }
                                         } else {
                                             // Portrait mode
+                                            val showBottomNav =
+                                                currentAudio == null || !playerSheetState.isExpanded
+                                            val playerSheetBottomPadding by animateDpAsState(
+                                                targetValue = if (showBottomNav) {
+                                                    if (interfaceSettings.experimentalFloatingNav) 78.dp else 68.dp
+                                                } else {
+                                                    0.dp
+                                                },
+                                                animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+                                                label = "playerSheetBottomPadding"
+                                            )
+
                                             AnimatedVisibility(
                                                 visible = currentAudio != null,
                                                 enter = slideInVertically(
@@ -477,7 +489,7 @@ class MainActivity : ComponentActivity() {
                                                 ) + fadeOut(),
                                                 modifier = Modifier
                                                     .align(Alignment.BottomCenter)
-                                                    .padding(bottom = if (interfaceSettings.experimentalFloatingNav) 78.dp else 68.dp)
+                                                    .padding(bottom = playerSheetBottomPadding)
                                             ) {
                                                 PlayerSheet(
                                                     sheetState = playerSheetState,
@@ -522,26 +534,24 @@ class MainActivity : ComponentActivity() {
                                                 )
                                             }
 
-                                            if (interfaceSettings.experimentalFloatingNav) {
-                                                AnimatedVisibility(
-                                                    visible = currentAudio == null || !playerSheetState.isExpanded,
-                                                    enter = slideInVertically(
-                                                        initialOffsetY = { fullHeight -> fullHeight }
-                                                    ) + fadeIn(),
-                                                    exit = slideOutVertically(
-                                                        targetOffsetY = { fullHeight -> fullHeight }
-                                                    ) + fadeOut(),
-                                                    modifier = Modifier.align(Alignment.BottomCenter),
-                                                ) {
+                                            AnimatedVisibility(
+                                                visible = showBottomNav,
+                                                enter = slideInVertically(
+                                                    initialOffsetY = { fullHeight -> fullHeight }
+                                                ) + fadeIn(),
+                                                exit = slideOutVertically(
+                                                    targetOffsetY = { fullHeight -> fullHeight }
+                                                ) + fadeOut(),
+                                                modifier = Modifier.align(Alignment.BottomCenter),
+                                            ) {
+                                                if (interfaceSettings.experimentalFloatingNav) {
                                                     FloatingOutifyBottomNav(
                                                         items = allRoutes,
                                                         selectedId = selectedId,
                                                         onItemSelected = { item -> if (backStack.last() != item.route) backStack.add(item.route) },
                                                         showSelectedLabel = interfaceSettings.navbarShowLabel,
                                                     )
-                                                }
-                                            } else {
-                                                Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                                                } else {
                                                     OutifyBottomNav(
                                                         items = allRoutes,
                                                         selectedId = selectedId,


### PR DESCRIPTION
## Summary
- Use one shared visibility state for the portrait bottom nav and player sheet bottom padding.
- Let the expanded player use the bottom space when the nav is hidden.

## Why
On compact portrait displays, the expanded player could keep bottom padding reserved for the nav even when the nav was hidden. That pushed playback controls off-screen. This is easiest to see on the Mudita Kompakt, but it can affect any short/compact portrait layout.

## Test
- ./gradlew :app:compileDebugKotlin