### PR TITLE
Fix Rust temp files on Android app storage

### DIFF
--- a/app/src/main/java/cc/tomko/outify/OutifyApplication.kt
+++ b/app/src/main/java/cc/tomko/outify/OutifyApplication.kt
@@ -1,6 +1,7 @@
 package cc.tomko.outify
 
 import android.app.Application
+import android.system.Os
 import android.util.Log
 import android.widget.Toast
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -44,6 +45,10 @@ class OutifyApplication : Application() {
     @UnstableApi
     override fun onCreate() {
         super.onCreate()
+
+        // Android <= 12: prevent Rust temp_dir() from using /data/local/tmp.
+        Os.setenv("TMPDIR", cacheDir.absolutePath, true)
+        Log.i("OutifyTMP", "TMPDIR=${System.getenv("TMPDIR")}")
         exceptionCollector.install()
 
         setDetailViewModelStore(detailViewModelStore)


### PR DESCRIPTION
## Summary
- Set TMPDIR to the app cache directory before native/Rust code starts.

## Why
On Android, Rust temp_dir() can resolve to /data/local/tmp when TMPDIR is unset. App processes should not rely on that shell-oriented path being writable. Android 12 devices such as the Mudita Kompakt expose this reliably, but the fix is generally safer for Android devices because temp files stay inside app-owned storage.

## Test
- ./gradlew :app:compileDebugKotlin
- Built and ran debug APK on Mudita Kompakt